### PR TITLE
Add server-side file size validation to OCR agent to prevent DoS

### DIFF
--- a/Agents/Hunyan_OCR_API_Multilingual_Translation_Agent_Example/app.py
+++ b/Agents/Hunyan_OCR_API_Multilingual_Translation_Agent_Example/app.py
@@ -22,6 +22,9 @@ st.set_page_config(
     layout="wide"
 )
 
+# Security: Maximum file size limit (10MB)
+MAX_FILE_SIZE = 10 * 1024 * 1024  # 10MB in bytes
+
 
 def encode_image(uploaded_file) -> str:
     """Convert uploaded file to base64 data URI."""
@@ -47,6 +50,11 @@ def main():
     
     # Translation workflow
     if uploaded_file and translate_button:
+        # Security: Validate file size before processing
+        if uploaded_file.size > MAX_FILE_SIZE:
+            st.error(f"❌ File size exceeds {MAX_FILE_SIZE // (1024 * 1024)}MB limit. Please upload a smaller image.")
+            return
+        
         with st.spinner("Processing..."):
             try:
                 # Step 1: Encode image

--- a/Agents/Hunyan_OCR_API_Multilingual_Translation_Agent_Example/pyproject.toml
+++ b/Agents/Hunyan_OCR_API_Multilingual_Translation_Agent_Example/pyproject.toml
@@ -11,4 +11,5 @@ dependencies = [
     "requests>=2.32.5",
     "streamlit>=1.53.0",
     "agno>=2.0.0",
+    "openai>=2.34.0",
 ]


### PR DESCRIPTION
## 🚀 Fix: Server-Side File Size Validation for OCR Upload

### Problem
The OCR agent did not enforce a server-side file size limit. This could allow large file uploads, leading to excessive memory usage and potential Denial of Service (DoS).

### Solution
- Added a file size validation check (10MB limit) in `Agents/OCR_Multilingual_Translation_Agent/app.py`
- Prevents processing of large files before OCR pipeline execution
- Displays an error message if file exceeds limit

### Impact
- Improves application stability
- Prevents resource exhaustion
- Enhances security

### Testing
- ✅ Small files (<10MB) are processed successfully
- ❌ Large files (>10MB) are rejected with an error message

Closes #1